### PR TITLE
Removed berkeley affiliation

### DIFF
--- a/frontend/src/shared/games/bridging_bot.ts
+++ b/frontend/src/shared/games/bridging_bot.ts
@@ -176,7 +176,7 @@ _You must read and agree to these terms to participate in the study._
 **Researchers:**
 
 - Jeffrey Fossett: Plurality Institute
-- Ian Baker: UC Berkeley & Plurality Institute
+- Ian Baker: Plurality Institute
 
 **Sponsor:** Plurality Institute
 


### PR DESCRIPTION
Removed Berkeley affiliation at the advice of UCB OPHS. We will depend on WCG instead.