### PR TITLE
Support for multiple experiment groups

### DIFF
--- a/frontend/src/components/experiment_dashboard/cohort_settings_dialog.ts
+++ b/frontend/src/components/experiment_dashboard/cohort_settings_dialog.ts
@@ -93,7 +93,7 @@ export class CohortSettingsDialog extends MobxLitElement {
                 cohort.id,
                 cohort.metadata,
                 cohort.participantConfig,
-                cohort.group, // Pass group to updateCohortMetadata
+                cohort.group,
               );
               this.experimentManager.setCohortEditing(undefined);
             }}

--- a/frontend/src/components/experiment_dashboard/cohort_settings_dialog.ts
+++ b/frontend/src/components/experiment_dashboard/cohort_settings_dialog.ts
@@ -24,6 +24,28 @@ export class CohortSettingsDialog extends MobxLitElement {
   private readonly analyticsService = core.getService(AnalyticsService);
   private readonly experimentManager = core.getService(ExperimentManager);
 
+  private renderGroup() {
+    const updateGroup = (e: InputEvent) => {
+      const group = (e.target as HTMLInputElement).value;
+      const cohort = this.experimentManager.cohortEditing;
+      if (!cohort) return;
+      this.experimentManager.setCohortEditing({
+        ...cohort,
+        group,
+      });
+    };
+    return html`
+      <pr-textarea
+        label="Experiment group (optional)"
+        placeholder="e.g., control, experiment_a, treatment"
+        variant="outlined"
+        .value=${this.experimentManager.cohortEditing?.group ?? ''}
+        @input=${updateGroup}
+      >
+      </pr-textarea>
+    `;
+  }
+
   override render() {
     if (!this.experimentManager.cohortEditing) {
       return nothing;
@@ -44,7 +66,7 @@ export class CohortSettingsDialog extends MobxLitElement {
           </pr-icon-button>
         </div>
         <div class="body">
-          ${this.renderName()} ${this.renderDescription()}
+          ${this.renderName()} ${this.renderGroup()} ${this.renderDescription()}
           ${this.renderMaxParticipantConfig()}
         </div>
         <div class="footer">
@@ -71,6 +93,7 @@ export class CohortSettingsDialog extends MobxLitElement {
                 cohort.id,
                 cohort.metadata,
                 cohort.participantConfig,
+                cohort.group, // Pass group to updateCohortMetadata
               );
               this.experimentManager.setCohortEditing(undefined);
             }}

--- a/frontend/src/components/experiment_dashboard/cohort_settings_dialog.ts
+++ b/frontend/src/components/experiment_dashboard/cohort_settings_dialog.ts
@@ -4,7 +4,7 @@ import '../../pair-components/textarea';
 
 import {MobxLitElement} from '@adobe/lit-mobx';
 import {CSSResultGroup, html, nothing} from 'lit';
-import {customElement, property} from 'lit/decorators.js';
+import {customElement} from 'lit/decorators.js';
 
 import '@material/web/checkbox/checkbox.js';
 
@@ -24,23 +24,24 @@ export class CohortSettingsDialog extends MobxLitElement {
   private readonly analyticsService = core.getService(AnalyticsService);
   private readonly experimentManager = core.getService(ExperimentManager);
 
-  private renderGroup() {
-    const updateGroup = (e: InputEvent) => {
-      const group = (e.target as HTMLInputElement).value;
+  private renderCondition() {
+    const updateCondition = (e: InputEvent) => {
+      const experimentalCondition = (e.target as HTMLInputElement).value;
       const cohort = this.experimentManager.cohortEditing;
       if (!cohort) return;
       this.experimentManager.setCohortEditing({
         ...cohort,
-        group,
+        experimentalCondition,
       });
     };
     return html`
       <pr-textarea
-        label="Experiment group (optional)"
+        label="Experimental condition (optional)"
         placeholder="e.g., control, experiment_a, treatment"
         variant="outlined"
-        .value=${this.experimentManager.cohortEditing?.group ?? ''}
-        @input=${updateGroup}
+        .value=${this.experimentManager.cohortEditing?.experimentalCondition ??
+        ''}
+        @input=${updateCondition}
       >
       </pr-textarea>
     `;
@@ -66,8 +67,8 @@ export class CohortSettingsDialog extends MobxLitElement {
           </pr-icon-button>
         </div>
         <div class="body">
-          ${this.renderName()} ${this.renderGroup()} ${this.renderDescription()}
-          ${this.renderMaxParticipantConfig()}
+          ${this.renderName()} ${this.renderCondition()}
+          ${this.renderDescription()} ${this.renderMaxParticipantConfig()}
         </div>
         <div class="footer">
           <pr-button
@@ -93,7 +94,7 @@ export class CohortSettingsDialog extends MobxLitElement {
                 cohort.id,
                 cohort.metadata,
                 cohort.participantConfig,
-                cohort.group,
+                cohort.experimentalCondition,
               );
               this.experimentManager.setCohortEditing(undefined);
             }}

--- a/frontend/src/services/experiment.manager.ts
+++ b/frontend/src/services/experiment.manager.ts
@@ -681,7 +681,7 @@ export class ExperimentManager extends Service {
     cohortId: string,
     metadata: MetadataConfig,
     participantConfig: CohortParticipantConfig,
-    group?: string,
+    experimentalCondition?: string,
   ) {
     if (!this.sp.experimentService.experiment) return;
 
@@ -696,7 +696,7 @@ export class ExperimentManager extends Service {
           cohortId,
           metadata,
           participantConfig,
-          group,
+          experimentalCondition,
         },
       );
     }

--- a/frontend/src/services/experiment.manager.ts
+++ b/frontend/src/services/experiment.manager.ts
@@ -681,6 +681,7 @@ export class ExperimentManager extends Service {
     cohortId: string,
     metadata: MetadataConfig,
     participantConfig: CohortParticipantConfig,
+    group?: string,
   ) {
     if (!this.sp.experimentService.experiment) return;
 
@@ -695,6 +696,7 @@ export class ExperimentManager extends Service {
           cohortId,
           metadata,
           participantConfig,
+          group,
         },
       );
     }

--- a/frontend/src/shared/games/bridging_bot.ts
+++ b/frontend/src/shared/games/bridging_bot.ts
@@ -30,6 +30,7 @@ import {
   SurveyQuestion,
   SurveyStageConfig,
   AgentPersonaType,
+  createCohortParticipantConfig,
 } from '@deliberation-lab/utils';
 
 export const BBOT_METADATA = createMetadataConfig({
@@ -602,6 +603,15 @@ const BBOT_TRANSFER_STAGE = createTransferStage({
   surveyStageId: 'reproductive_rights_survey_pre',
   surveyQuestionId: 'abortion_policy_preference',
   participantCounts: {illegal: 1, legal: 1},
+  newCohortParticipantConfig: createCohortParticipantConfig({
+    maxParticipantsPerCohort: 2,
+    includeAllParticipantsInCohortCount: false,
+  }),
+  groupProbabilities: {
+    control: 0.3334, // No moderator message
+    fixed: 0.3333, // Standard pre-written message
+    bot: 0.3333, // AI moderation message
+  },
 });
 
 const BBOT_CHAT_INTRO_TEXT = `In the next stage, you will have a chat conversation about abortion policy with another participant who may see the issue differently.

--- a/frontend/src/shared/games/bridging_bot.ts
+++ b/frontend/src/shared/games/bridging_bot.ts
@@ -607,7 +607,7 @@ const BBOT_TRANSFER_STAGE = createTransferStage({
     maxParticipantsPerCohort: 2,
     includeAllParticipantsInCohortCount: false,
   }),
-  groupProbabilities: {
+  conditionProbabilities: {
     control: 0.3334, // No moderator message
     fixed: 0.3333, // Standard pre-written message
     bot: 0.3333, // AI moderation message

--- a/functions/src/cohort.endpoints.ts
+++ b/functions/src/cohort.endpoints.ts
@@ -21,7 +21,7 @@ import {
   prettyPrintError,
   prettyPrintErrors,
 } from './utils/validation';
-import { createCohortInternal } from './cohort.utils';
+import {createCohortInternal} from './cohort.utils';
 
 /** Create/update and delete cohorts. */
 
@@ -52,11 +52,7 @@ export const createCohort = onCall(async (request) => {
 
   // Run document write as transaction to ensure consistency
   await app.firestore().runTransaction(async (transaction) => {
-    await createCohortInternal(
-      transaction,
-      data.experimentId,
-      cohortConfig,
-    );
+    await createCohortInternal(transaction, data.experimentId, cohortConfig);
   });
 
   return {id: cohortConfig.id};
@@ -110,8 +106,14 @@ export const updateCohortMetadata = onCall(async (request) => {
     // Update date edited
     const metadata = {...data.metadata, dateModified: Timestamp.now()};
     const participantConfig = data.participantConfig;
+    const group = data.group !== undefined ? data.group : cohortConfig.group;
 
-    transaction.set(document, {...cohortConfig, metadata, participantConfig});
+    transaction.set(document, {
+      ...cohortConfig,
+      metadata,
+      participantConfig,
+      group,
+    });
   });
 
   return {success};

--- a/functions/src/cohort.endpoints.ts
+++ b/functions/src/cohort.endpoints.ts
@@ -106,13 +106,13 @@ export const updateCohortMetadata = onCall(async (request) => {
     // Update date edited
     const metadata = {...data.metadata, dateModified: Timestamp.now()};
     const participantConfig = data.participantConfig;
-    const group = data.group !== undefined ? data.group : cohortConfig.group;
+    const experimentalCondition = cohortConfig.experimentalCondition;
 
     transaction.set(document, {
       ...cohortConfig,
       metadata,
       participantConfig,
-      group,
+      experimentalCondition,
     });
   });
 

--- a/functions/src/participant.utils.ts
+++ b/functions/src/participant.utils.ts
@@ -15,7 +15,7 @@ import {
 import {completeStageAsAgentParticipant} from './agent.utils';
 import {getFirestoreActiveParticipants} from './utils/firestore';
 import {generateId} from '@deliberation-lab/utils';
-import { createCohortInternal } from './cohort.utils';
+import {createCohortInternal} from './cohort.utils';
 
 import {app} from './app';
 
@@ -25,7 +25,10 @@ export async function updateParticipantNextStage(
   participant: ParticipantProfileExtended,
   stageIds: string[],
 ) {
-  const response = {currentStageId: null as (string | null), endExperiment: false};
+  const response = {
+    currentStageId: null as string | null,
+    endExperiment: false,
+  };
 
   const currentStageId = participant.currentStageId;
   const currentStageIndex = stageIds.indexOf(currentStageId);
@@ -183,7 +186,7 @@ export async function handleAutomaticTransfer(
   experimentId: string,
   stageConfig: TransferStageConfig,
   participant: ParticipantProfileExtended,
-): Promise<{ currentStageId: string; endExperiment: boolean } | null> {
+): Promise<{currentStageId: string; endExperiment: boolean} | null> {
   const firestore = app.firestore();
 
   // Do a read to lock the current participant's document for this transaction
@@ -205,7 +208,7 @@ export async function handleAutomaticTransfer(
         .where('currentStageId', '==', stageConfig.id)
         .where('currentStatus', '==', ParticipantStatus.IN_PROGRESS)
         .where('currentCohortId', '==', participant.currentCohortId)
-        .where('transferCohortId', '==', null)
+        .where('transferCohortId', '==', null),
     )
   ).docs.map((doc) => doc.data() as ParticipantProfileExtended);
 
@@ -216,9 +219,7 @@ export async function handleAutomaticTransfer(
   }
 
   // Filter connected participants
-  const connectedParticipants = waitingParticipants.filter(
-    (p) => p.connected,
-  );
+  const connectedParticipants = waitingParticipants.filter((p) => p.connected);
 
   console.log(
     `Connected participants for transfer stage ${stageConfig.id}: ${connectedParticipants
@@ -235,9 +236,9 @@ export async function handleAutomaticTransfer(
     .collection('publicStageData')
     .doc(stageConfig.surveyStageId!);
 
-  const surveyStageData = (
-    await transaction.get(surveyStageDoc)
-  ).data() as SurveyStagePublicData | undefined;
+  const surveyStageData = (await transaction.get(surveyStageDoc)).data() as
+    | SurveyStagePublicData
+    | undefined;
 
   if (!surveyStageData) {
     throw new Error('Survey stage data not found');
@@ -249,21 +250,28 @@ export async function handleAutomaticTransfer(
   // Group participants by survey answers
   const answerGroups: Record<string, ParticipantProfileExtended[]> = {};
   for (const connectedParticipant of connectedParticipants) {
-    const surveyAnswers = surveyStageData.participantAnswerMap[connectedParticipant.publicId];
+    const surveyAnswers =
+      surveyStageData.participantAnswerMap[connectedParticipant.publicId];
     if (!surveyAnswers) {
-      console.log(`Participant ${connectedParticipant.publicId} has no survey answers`);
+      console.log(
+        `Participant ${connectedParticipant.publicId} has no survey answers`,
+      );
       continue;
     }
 
     const surveyAnswer = surveyAnswers[stageConfig.surveyQuestionId!];
     if (!surveyAnswer) {
-      console.log(`Participant ${connectedParticipant.publicId} has no survey answer matching ${stageConfig.surveyQuestionId}`);
+      console.log(
+        `Participant ${connectedParticipant.publicId} has no survey answer matching ${stageConfig.surveyQuestionId}`,
+      );
       continue;
     }
 
     // Only support multiple-choice questions for now
     if (surveyAnswer.kind !== SurveyQuestionKind.MULTIPLE_CHOICE) {
-      throw new Error(`Selected survey answer is not of kind ${SurveyQuestionKind.MULTIPLE_CHOICE}`);
+      throw new Error(
+        `Selected survey answer is not of kind ${SurveyQuestionKind.MULTIPLE_CHOICE}`,
+      );
     }
 
     const key = surveyAnswer.choiceId;
@@ -271,7 +279,9 @@ export async function handleAutomaticTransfer(
       answerGroups[key] = [];
     }
     answerGroups[key].push(connectedParticipant);
-    console.log(`Participant ${connectedParticipant.publicId} has answer ${key}`);
+    console.log(
+      `Participant ${connectedParticipant.publicId} has answer ${key}`,
+    );
   }
 
   // Check if a cohort can be formed
@@ -282,14 +292,21 @@ export async function handleAutomaticTransfer(
 
     // Sort by waiting time (oldest first)
     matchingParticipants = matchingParticipants.sort((a, b) => {
-      const aTime = a.timestamps.readyStages?.[stageConfig.id]?.toMillis?.() ?? 0;
-      const bTime = b.timestamps.readyStages?.[stageConfig.id]?.toMillis?.() ?? 0;
+      const aTime =
+        a.timestamps.readyStages?.[stageConfig.id]?.toMillis?.() ?? 0;
+      const bTime =
+        b.timestamps.readyStages?.[stageConfig.id]?.toMillis?.() ?? 0;
       return aTime - bTime;
     });
 
     // Move the current participant to the front if present
-    matchingParticipants = matchingParticipants.filter(p => p.privateId === participant.privateId)
-      .concat(matchingParticipants.filter(p => p.privateId !== participant.privateId));
+    matchingParticipants = matchingParticipants
+      .filter((p) => p.privateId === participant.privateId)
+      .concat(
+        matchingParticipants.filter(
+          (p) => p.privateId !== participant.privateId,
+        ),
+      );
 
     // If not enough participants to form a cohort, return null
     if (matchingParticipants.length < requiredCount) {
@@ -302,16 +319,51 @@ export async function handleAutomaticTransfer(
     cohortParticipants.push(...matchingParticipants.slice(0, requiredCount));
   }
 
-  // nb: for transaction purposes, writes begin here and there can be no more reads.
+  // Select group if groupProbabilities is provided
+  let selectedGroup: string | undefined = undefined;
+  if (stageConfig.groupProbabilities) {
+    const groupProbabilities = stageConfig.groupProbabilities;
+    const groups = Object.keys(groupProbabilities);
+    const probs = Object.values(groupProbabilities);
+    const sum = probs.reduce((a, b) => a + b, 0);
+    if (Math.abs(sum - 1) > 1e-6) {
+      throw new Error('groupProbabilities must sum to 1');
+    }
+    const r = Math.random();
+    let acc = 0;
+    for (let i = 0; i < groups.length; i++) {
+      acc += probs[i]; // builds a cdf over probs
+      if (r < acc) {
+        selectedGroup = groups[i];
+        break;
+      }
+    }
+  }
 
   // Create a new cohort and transfer participants
+  // Get the current number of cohorts for this experiment
+  const cohortsSnapshot = await transaction.get(
+    firestore.collection('experiments').doc(experimentId).collection('cohorts'),
+  );
+  const cohortCount = cohortsSnapshot.size; // Will always be 1 greater than the number of cohorts, since that is zero-based
+  const groupName = selectedGroup
+    ? `${selectedGroup} ${cohortCount}`
+    : `Cohort ${cohortCount}`;
   const cohortConfig = createCohortConfig({
     id: generateId(),
-    metadata: createMetadataConfig({ creator: 'system', dateCreated: Timestamp.now(), dateModified: Timestamp.now() }),
+    metadata: createMetadataConfig({
+      creator: 'system',
+      dateCreated: Timestamp.now(),
+      dateModified: Timestamp.now(),
+      name: groupName,
+    }),
     participantConfig: stageConfig.newCohortParticipantConfig,
+    group: selectedGroup,
   });
 
-  console.log(`Creating cohort ${cohortConfig.id} for participants: ${cohortParticipants.map((p) => p.publicId).join(', ')}`);
+  console.log(
+    `Creating cohort ${cohortConfig.id} for participants: ${cohortParticipants.map((p) => p.publicId).join(', ')} group: ${selectedGroup}`,
+  );
 
   await createCohortInternal(transaction, experimentId, cohortConfig);
 
@@ -327,7 +379,9 @@ export async function handleAutomaticTransfer(
       currentStatus: ParticipantStatus.TRANSFER_PENDING,
     });
 
-    console.log(`Transferring participant ${participant.publicId} to cohort ${cohortConfig.id}`);
+    console.log(
+      `Transferring participant ${participant.publicId} to cohort ${cohortConfig.id}`,
+    );
   }
 
   // Update the passed-in participant as a side-effect, since this is how we merge all the changes
@@ -335,7 +389,7 @@ export async function handleAutomaticTransfer(
   participant.currentStatus = ParticipantStatus.TRANSFER_PENDING;
   participant.transferCohortId = cohortConfig.id;
 
-  return { currentStageId: stageConfig.id, endExperiment: false };
+  return {currentStageId: stageConfig.id, endExperiment: false};
 }
 
 /** Fetch a participant record by experimentId and participantId. */

--- a/functions/src/participant.utils.ts
+++ b/functions/src/participant.utils.ts
@@ -341,6 +341,13 @@ export async function handleAutomaticTransfer(
   }
 
   // Create a new cohort and transfer participants
+  // Fetch experiment metadata to get the creator
+  const experimentDoc = await transaction.get(
+    firestore.collection('experiments').doc(experimentId),
+  );
+  const experimentData = experimentDoc.data() as Experiment;
+  const experimentCreator = experimentData?.metadata?.creator || 'system';
+
   // Get the current number of cohorts for this experiment
   const cohortsSnapshot = await transaction.get(
     firestore.collection('experiments').doc(experimentId).collection('cohorts'),
@@ -352,7 +359,7 @@ export async function handleAutomaticTransfer(
   const cohortConfig = createCohortConfig({
     id: generateId(),
     metadata: createMetadataConfig({
-      creator: 'system',
+      creator: experimentCreator, // set to experiment creator
       dateCreated: Timestamp.now(),
       dateModified: Timestamp.now(),
       name: groupName,

--- a/utils/src/cohort.ts
+++ b/utils/src/cohort.ts
@@ -22,7 +22,7 @@ export interface CohortConfig {
   participantConfig: CohortParticipantConfig;
   // Maps stage ID to whether stage is unlocked (i.e., participants are ready)
   stageUnlockMap: Record<string, boolean>;
-  group?: string; // Freeform string for experiment group tracking
+  experimentalCondition?: string; // Freeform string for experiment group tracking
 }
 
 // ************************************************************************* //
@@ -39,6 +39,6 @@ export function createCohortConfig(
     participantConfig:
       config.participantConfig ?? createCohortParticipantConfig(),
     stageUnlockMap: config.stageUnlockMap ?? {},
-    group: config.group ?? '',
+    experimentalCondition: config.experimentalCondition ?? '',
   };
 }

--- a/utils/src/cohort.ts
+++ b/utils/src/cohort.ts
@@ -22,7 +22,7 @@ export interface CohortConfig {
   participantConfig: CohortParticipantConfig;
   // Maps stage ID to whether stage is unlocked (i.e., participants are ready)
   stageUnlockMap: Record<string, boolean>;
-  experimentalCondition?: string; // Freeform string for experiment group tracking
+  experimentalCondition?: string; // Freeform string for experiment condition (control, treatment, etc) tracking
 }
 
 // ************************************************************************* //

--- a/utils/src/cohort.ts
+++ b/utils/src/cohort.ts
@@ -22,6 +22,7 @@ export interface CohortConfig {
   participantConfig: CohortParticipantConfig;
   // Maps stage ID to whether stage is unlocked (i.e., participants are ready)
   stageUnlockMap: Record<string, boolean>;
+  group?: string; // Freeform string for experiment group tracking
 }
 
 // ************************************************************************* //
@@ -38,5 +39,6 @@ export function createCohortConfig(
     participantConfig:
       config.participantConfig ?? createCohortParticipantConfig(),
     stageUnlockMap: config.stageUnlockMap ?? {},
+    group: config.group ?? '',
   };
 }

--- a/utils/src/cohort.validation.ts
+++ b/utils/src/cohort.validation.ts
@@ -19,6 +19,7 @@ export const CohortCreationData = Type.Object(
         metadata: MetadataConfigSchema,
         participantConfig: CohortParticipantConfigSchema,
         stageUnlockMap: Type.Record(Type.String(), Type.Boolean()),
+        group: Type.Optional(Type.String()),
       },
       strict,
     ),

--- a/utils/src/cohort.validation.ts
+++ b/utils/src/cohort.validation.ts
@@ -39,6 +39,7 @@ export const UpdateCohortMetadataData = Type.Object(
     cohortId: Type.String({minLength: 1}),
     metadata: MetadataConfigSchema,
     participantConfig: CohortParticipantConfigSchema,
+    group: Type.Optional(Type.String()),
   },
   strict,
 );

--- a/utils/src/cohort.validation.ts
+++ b/utils/src/cohort.validation.ts
@@ -19,7 +19,7 @@ export const CohortCreationData = Type.Object(
         metadata: MetadataConfigSchema,
         participantConfig: CohortParticipantConfigSchema,
         stageUnlockMap: Type.Record(Type.String(), Type.Boolean()),
-        group: Type.Optional(Type.String()),
+        experimentalCondition: Type.Optional(Type.String()),
       },
       strict,
     ),
@@ -39,7 +39,7 @@ export const UpdateCohortMetadataData = Type.Object(
     cohortId: Type.String({minLength: 1}),
     metadata: MetadataConfigSchema,
     participantConfig: CohortParticipantConfigSchema,
-    group: Type.Optional(Type.String()),
+    experimentalCondition: Type.Optional(Type.String()),
   },
   strict,
 );

--- a/utils/src/stages/transfer_stage.ts
+++ b/utils/src/stages/transfer_stage.ts
@@ -23,7 +23,7 @@ export interface TransferStageConfig extends BaseStageConfig {
   surveyQuestionId?: string; // ID of the survey question to reference
   participantCounts?: {[key: string]: number}; // Map of serialized survey answers to required participant counts
   newCohortParticipantConfig?: CohortParticipantConfig; // Cohort participant config for new cohorts
-  groupProbabilities?: Record<string, number>; // Map of group name to probability. Must sum to 1.
+  conditionProbabilities?: Record<string, number>; // Map of experimental condition to probability. Must sum to 1.
 }
 
 // ************************************************************************* //
@@ -51,6 +51,6 @@ export function createTransferStage(
     surveyQuestionId: config.surveyQuestionId,
     participantCounts: config.participantCounts,
     newCohortParticipantConfig: config.newCohortParticipantConfig,
-    groupProbabilities: config.groupProbabilities,
+    conditionProbabilities: config.conditionProbabilities,
   };
 }

--- a/utils/src/stages/transfer_stage.ts
+++ b/utils/src/stages/transfer_stage.ts
@@ -21,8 +21,9 @@ export interface TransferStageConfig extends BaseStageConfig {
   enableSurveyMatching?: boolean; // Whether to enable survey-based participant matching
   surveyStageId?: string; // ID of the survey stage to reference
   surveyQuestionId?: string; // ID of the survey question to reference
-  participantCounts?: { [key: string]: number }; // Map of serialized survey answers to required participant counts
+  participantCounts?: {[key: string]: number}; // Map of serialized survey answers to required participant counts
   newCohortParticipantConfig?: CohortParticipantConfig; // Cohort participant config for new cohorts
+  groupProbabilities?: Record<string, number>; // Map of group name to probability. Must sum to 1.
 }
 
 // ************************************************************************* //
@@ -49,5 +50,7 @@ export function createTransferStage(
     surveyStageId: config.surveyStageId,
     surveyQuestionId: config.surveyQuestionId,
     participantCounts: config.participantCounts,
+    newCohortParticipantConfig: config.newCohortParticipantConfig,
+    groupProbabilities: config.groupProbabilities,
   };
 }

--- a/utils/src/stages/transfer_stage.validation.ts
+++ b/utils/src/stages/transfer_stage.validation.ts
@@ -24,7 +24,7 @@ export const TransferStageConfigData = Type.Object(
     progress: StageProgressConfigSchema,
     enableTimeout: Type.Boolean(),
     timeoutSeconds: Type.Number(),
-    groupProbabilities: Type.Optional(
+    conditionProbabilities: Type.Optional(
       Type.Record(Type.String(), Type.Number()),
     ),
   },

--- a/utils/src/stages/transfer_stage.validation.ts
+++ b/utils/src/stages/transfer_stage.validation.ts
@@ -24,6 +24,9 @@ export const TransferStageConfigData = Type.Object(
     progress: StageProgressConfigSchema,
     enableTimeout: Type.Boolean(),
     timeoutSeconds: Type.Number(),
+    groupProbabilities: Type.Optional(
+      Type.Record(Type.String(), Type.Number()),
+    ),
   },
   strict,
 );


### PR DESCRIPTION
This PR adds multiple experiment group support, by setting a `group` field on each auto-generated cohort (and renaming it for clarity). The field isn't used to change the behavior of the experiment yet, but now we can have the chat stage respond to which cohort it's a part of.