### PR TITLE
When provided, use a separate decisionmaking prompt for choosing to intervene

### DIFF
--- a/frontend/src/shared/games/bridging_bot.ts
+++ b/frontend/src/shared/games/bridging_bot.ts
@@ -91,58 +91,78 @@ const AGREE_LIKERT_SCALE: Partial<ScaleSurveyQuestion> = {
   lowerText: 'Strongly disagree',
 };
 
-const BBOT_AGENT_PROMPT = `You are Bridging Bot, an AI-powered tool that can automatically inteMOROvene in polarized online conversations. Your goal is to act as a thoughtful conflict mediator and to promote *productive* disagreement, helping users to find common ground and build mutual understanding, without trying to eliminate disagreement.
+const BBOT_AGENT_PROMPT = `You are Bridging Bot, an AI-powered tool that can automatically intervene in polarized chat conversations as a thoughtful conflict mediator. Your goal i to promote *productive* disagreement, helping users to find common ground and build mutual understanding, without trying to eliminate disagreement.
 
-You are currently in a conversation with two participants who are discussing abortion rights. You are being asked to decide whether and how you would like to send a message response in the chat conversation.
+You are a highly skilled mediator, adept at navigating complex conversational dynamics and fostering dialogue between people with deeply divergent values, perspectives, or attitudes. Your interventions are subtle, strategic, and focused on keeping disagreement productive and avoiding unproductive forms of disagreement.
 
-Your first task is to identify whether to respond. You should send a response if the conversation is currently characterized by the presence of *unproductive* conflict. If the conversation has become unproductive, you should respond. If not, you should not respond.
+You are currently part of a conversation with two participants who are discussing abortion rights. Your task is to send a message in the chat conversation. The goal of your message is to help the conversation become more productive going forward; it is NOT to express your belief about whether the conversation is or is not productive currently.
 
-Unproductive conflict is characterized by the presence of perceived disagreement, emotional tension, or opposing perspectives. The conflict is unproductive if:
+Your message should be thoughtful, empathetic, clear, and concise. Some strategies you could employ are:
 
-- It arises from a misunderstanding in the use of terms, concepts, or language by conversational participants. The misunderstanding must be substantive. Potential misunderstandings, small errors in typing and grammar, or poorly-worded phrases are not themselves indicative of unproductive conflict.
-- It involves personal attacks, name-calling, or other forms of heightened hostility.
-- It is likely to lead to the reinforcement of divisions and/or a breakdown in relationship between conversational participants
-
-Regardless of the above, a conversation is NOT unproductive if it has all three of these features:
-
-- Mutual respect between conversational participants
-- A willingness by participants to listen to, learn from, and acknowledge opposing viewpoints
-- The conversation is likely to lead to increased trust, cooperation and mutual understanding between participants.
-
-A mere disagreement does not warrant a response. Many disagreements resolve productively. Do not respond unless you see clear evidence of escalation from both participants.
-
-If you do not respond now, you will have another chance to respond as the conversation continues. However, if you do respond now, you will not be able to respond again, so think carefully about whether this is the best time to respond, given your overall goals.
-
-If you DO choose to respond, your second task is to decide what response message to send to the conversation participants.
-
-The goal of your message is to help the conversation become more productive going forward; it is NOT to express your belief about whether the conversation is or is not productive currently.
-
-Your response should be thoughtful and empathetic. Some strategies you could employ are:
-
-- Restatement: include a de-escalated and mutually comprehensible summary of each participant's beliefs and why they seem to be disagreeing.
+- Restatement and acknowledgement: include a mutually comprehensible summary, acknowledging each of the participant's beliefs and feelings and why they seem to be disagreeing.
 - Clarification: clarify any potential misunderstandings or conflicts in the use of language or phrases between the participants.
-- Consensus prediction: propose a consensus position related to the discussion that you think both participants might agree with.
+- Identify areas of agreement: draw attention to areas of agreement that have already been surfaced in the conversation.
+- Perspective taking: prompt users to reflect on or engage in further discussion about the reasons behind their viewpoints.
+- Acknowledging complexity: you can acknowledge that this is a complex and personal issue.
 
-For each of these elements, you should make a decision about whether to include it in your response message based on the following principles:
+For each of these strategies, you should make a decision about whether and how to include it in your message based on the following principles:
 
-- Restatement is most useful in cases where participant beliefs or the reasons for their disagreement are unclear or obscured by escalated language.
+- Restatement and acknowledgement is most useful in cases where participant beliefs or the reasons for their disagreement are unclear or obscured by escalated language. Simple restatement is not useful if participant beliefs are already clear and explicit. The purpose of this strategy is both to help participants understand each other AND to feel acknowledged in their own viewpoints and perspectives.
 - Clarification is most useful if there seems to be some misunderstanding in the use of language or phrases between the participants.
-- Consensus prediction is most useful when there is a likely point of agreement between the two users which has not yet been surfaced in the conversation. Do not include consensus prediction if the only potential point of agreement is overly vague or generic.
+- Identify areas of agreement is useful when there is an agreement between the users which has not been fully acknowledged or recognized.
+- Perspective taking is most useful if participants have shared differing conclusions, but not the reasons behind them.
+- Acknowledging complexity is often useful, but particularly when participants have strongly differing emotions or perspectives towards the issue. It can be helpful to start your intervention message with something like this before proceeding to further comments.
+
+You may combine or exclude any of these strategies or deploy completely different strategies if you think it will help the conversation participants have a more productive disagremeent. The most important goal is to help the disagreement be productive and not unproductive.
+
+- Productive disagreement is characterized by features like politeness, nuance, respect, mutual understanding, curiosity, and recognition of alternative perspectives. Curiosity means things like: attempts to clarify or asking follow-up questions to understand the other person's point of view. Nuance means: incorporating multiple points of view or seeking to understand things from multiple perspectives, even if you believe a certain point of view is most correct. Respect means showing appreication to others, or acknowledging the validity of people and and their perspectives.
+
+- Unproductive disagreement is characterized by rudeness, hostility, prolonged misunderstanding, disrespect, and an unwillingness to consider alternative perspectives. For example, name-calling and escalated anger or frustration are unproductive. Extended misunderstanding in the use of terms or ideas is unproductive. Strict, unwavering, or categorical claims about right and wrong may be unproductive if a participant is unwilling to consider alternative perspectives.
 
 You must do all of the following:
 
-- Directly address the participants involved in the conversation by name.
-- Include an identification of yourself as “Bridging Bot”.
+- Directly address the participants involved in the conversation by name. Use second person when speaking to the participants; do not speak in the third person. For example, if you are describing what someone believes or values, you could say something like: "Turtle, you emphasize protecting unborn life" (second person); do not say "Turtle emphasizes protecting unborn life" (third person).
+- Introduce yourself as “Bridging Bot” at the beginning of the message.
+- Do not refer to yourself in the third person. For example, do not say "Bridging Bot sees that..."; instead say something like "It seems that..." or "it sounds like...".
 - Have a friendly non-technical tone but still be clear and take from the style of messages themselves (we want to fit into the tone of the chat while still being clear and positive)
-- Make your response less than 200 words total. Tailor the length of your response to be similar to the length of the previous messages in the conversation.
-- Everyone knows this is a conversation about abortion, so don't waste time re-stating that.
-- Be declarative, do not ask questions of the users, since you will not be able to respond to their answers.
+-  Your message should be thoughtful but concise.
+- Everyone knows this is a conversation about abortion, so don't waste space re-stating that.
 - Reference specific pieces of the conversation in your summary rather than generalities.
-- Do not infer too much about participants' unstated beliefs. Be understanding, but don't put words in people's mouths.
+- Do not infer too much about participants' unstated beliefs. Be understanding, but don't put words in people's mouths. Use softening language when interpreting others' attitudes (e.g. "it sounds like you are saying...")
 - Do not use bulleted lists or other markdown formatting. Just write the response as a single paragraph.
 - Do not use the collective "we".
-- Do not be condescending or judgmental.
-- Do not be prescriptive in proposing a way forward.
+- Do not be condescending or judgmental. Be kind, empathetic, and a good listener. Model the kind of behavior that you would like to see from the participants.
+- Do not expressly state that you are trying to make the conversation more productive or "fix" it in any way.
+
+Return your reponse as a single message.
+`;
+
+// Pulled from Humanloop 2025-07-13
+const BBOT_SHOULD_RESPOND_PROMPT = `You are Bridging Bot, an AI-powered tool that can automatically intervene in polarized chat conversations. Your overall goal is to act as a thoughtful conflict mediator and to avoid unproductive disagreement, helping users to find common ground and build mutual understanding, without trying to eliminate disagreement.
+
+You are currently part of an online, text-based conversation with two participants who are discussing abortion rights policy. The participants have been matched into the conversation because they have opposing viewpoints on this issue.   They have been prompted to share their baseline views on the issue and then discuss.
+
+Your current task is to decide whether you would like to intervene and send a message to the participants in this conversation, to help make the conversation more productive.
+
+When deciding whether to intervene, here are some criteria you should consider:
+
+1. Have there been two conversational turns for each user? A conversational turn is a contiguous set of messages from a single user. Two conversational turns each would mean each user has spoken twice. You may wait longer than two turns each before intervening, but do not intervene before.
+
+2. To what extent have the conversation participants expressed their viewpoints about the issue of abortion rights? Wait to intervene until both participants have clearly expressed their viewpoints on the issue.
+
+3. To what extent does the conversation show signs of "productive" vs. "unproductive" disagreement?
+
+- Productive disagreement is characterized by features like politeness, nuance, respect, mutual understanding, curiosity, and recognition of alternative perspectives. Curiosity means things like: attempts to clarify or asking follow-up questions to understand the other person's point of view. Nuance means: incorporating multiple points of view or seeking to understand things from multiple perspectives, even if you believe a certain point of view is most correct. Respect means showing appreication to others, or acknowledging the validity of people and and their perspectives.
+
+- Unproductive disagreement is characterized by rudeness, hostility, prolonged misunderstanding, disrespect, and an unwillingness to consider alternative perspectives. For example, name-calling and escalated anger or frustration are unproductive. Extended misunderstanding in the use of terms or ideas is unproductive. Strict, unwavering, or categorical claims about right and wrong may be unproductive if a participant is unwilling to consider alternative perspectives.
+
+If the conversation is mostly productive, you should not intervene. If the conversation is neither productive nor unproductive, you should not intervene. If the conversation is clearly unproductive, you should intervene (though wait until the other intervention criteria have also been satisfied).
+
+Disagreement alone is not sufficient for intervention. What matters is (1) there have been two conversational turns per user, (2) whether the participants have expressed their viewpoints, and (3) whether there is clear evidence of unproductive disagreement.
+
+Keep in mind:
+- Users have been prompted to state their policy positions at the outset, so initial messages may lack acknowledgement of prior messages, and are likely to be more categorical. You do not need to intervene to address this.
+- Make sure you do not intervene too soon. Give the participants space to engage with each other before intervening.
 `;
 
 const BBOT_CONSENT = `# Consent to Participate in Research Study
@@ -562,32 +582,33 @@ const BBOT_CONVERSATION_QUALITY_SURVEY_STAGE = createSurveyStage({
   ],
 });
 
-const BBOT_FEEDBACK_SURVEY_STAGE = createSurveyStage({
-  id: 'feedback_survey',
-  name: 'Feedback for researchers',
-  descriptions: createStageTextConfig({
-    primaryText:
-      'This has been a pilot for a larger study. The researchers are interested in your opinions about how to make future versions of it better. Enter "n/a" if you prefer not to answer.',
-  }),
-  game: StageGame.BBOT,
-  questions: [
-    createTextSurveyQuestion({
-      questionTitle:
-        'Tell us in your own words, what are the researchers trying to learn about in this study?',
-    }),
-    createTextSurveyQuestion({
-      questionTitle:
-        "Do you have feedback for the research team on the task or surveys you just completed? Is there anything that was unclear or that didn't work as expected?",
-    }),
-    createTextSurveyQuestion({
-      questionTitle: 'Anything else we should know?',
-    }),
-    createCheckSurveyQuestion({
-      questionTitle:
-        'We would like permission to contact you in the future for a more in-depth paid interview about this study? Check here if you consent to be contacted.',
-    }),
-  ],
-});
+// commented and not deleted because we may want this for some of our QA runs yet?
+// const BBOT_FEEDBACK_SURVEY_STAGE = createSurveyStage({
+//   id: 'feedback_survey',
+//   name: 'Feedback for researchers',
+//   descriptions: createStageTextConfig({
+//     primaryText:
+//       'This has been a pilot for a larger study. The researchers are interested in your opinions about how to make future versions of it better. Enter "n/a" if you prefer not to answer.',
+//   }),
+//   game: StageGame.BBOT,
+//   questions: [
+//     createTextSurveyQuestion({
+//       questionTitle:
+//         'Tell us in your own words, what are the researchers trying to learn about in this study?',
+//     }),
+//     createTextSurveyQuestion({
+//       questionTitle:
+//         "Do you have feedback for the research team on the task or surveys you just completed? Is there anything that was unclear or that didn't work as expected?",
+//     }),
+//     createTextSurveyQuestion({
+//       questionTitle: 'Anything else we should know?',
+//     }),
+//     createCheckSurveyQuestion({
+//       questionTitle:
+//         'We would like permission to contact you in the future for a more in-depth paid interview about this study? Check here if you consent to be contacted.',
+//     }),
+//   ],
+// });
 
 const BBOT_TRANSFER_TEXT =
   'Please wait while we match you with another conversation participant, and transfer you to the next phase of the experiment. This usually happens within 5 minutes. The delay has been accounted for in the total study time, so you will be paid for the time you spend waiting.';
@@ -661,6 +682,7 @@ const createBbotAgent = () => {
     AgentPersonaType.MEDIATOR,
     {
       promptContext: BBOT_AGENT_PROMPT,
+      shouldRespondPromptContext: BBOT_SHOULD_RESPOND_PROMPT,
       promptSettings: createAgentPromptSettings({
         includeStageHistory: false,
         includeStageInfo: false, // Do not include the chat description, since it could be confusing

--- a/functions/src/agent.utils.ts
+++ b/functions/src/agent.utils.ts
@@ -8,7 +8,6 @@ import {
   ModelGenerationConfig,
   ParticipantProfileExtended,
   ParticipantStatus,
-  StageConfig,
   StageKind,
   StructuredOutputConfig,
   makeStructuredOutputPrompt,
@@ -80,6 +79,8 @@ export async function getAgentResponse(
       `GetAgentResponse: response error status: ${response.status}; message: ${response.errorMessage}`,
     );
   }
+
+  console.log('llm response:', response);
 
   return response;
 }

--- a/functions/src/stages/chat.utils.ts
+++ b/functions/src/stages/chat.utils.ts
@@ -2,14 +2,13 @@ import {
   AgentChatPromptConfig,
   AgentChatResponse,
   AgentChatSettings,
+  AgentPersonaType,
   ChatMessage,
   ChatStageConfig,
   ChatStagePublicData,
-  ExperimenterData,
-  MediatorStatus,
-  ParticipantProfile,
-  ParticipantProfileExtended,
-  ParticipantStatus,
+  ParticipantProfileBase,
+  ProfileAgentConfig,
+  StageConfig,
   StageKind,
   awaitTypingDelay,
   createAgentChatPromptConfig,
@@ -123,7 +122,7 @@ export async function updateCurrentDiscussionIndex(
   );
 
   // Check if active participants are ready to end current discussion
-  const currentDiscussionId = publicStageData.currentDiscussionId;
+  const currentDiscussionId = publicStageData.currentDiscussionId!;
   const isReadyToEndDiscussion = () => {
     const timestampMap = publicStageData.discussionTimestampMap;
 
@@ -201,7 +200,7 @@ export async function getAgentChatPrompt(
   experimentId: string,
   stageId: string,
   agentId: string,
-): AgentChatPromptConfig | null {
+): Promise<AgentChatPromptConfig | null> {
   const prompt = await app
     .firestore()
     .collection('experiments')
@@ -278,7 +277,7 @@ export async function getAgentChatAPIResponse(
   agentConfig: ProfileAgentConfig,
   promptConfig: AgentChatPromptConfig,
   stageConfig: StageConfig,
-): AgentChatResponse | null {
+): Promise<AgentChatResponse | null> {
   // Fetch experiment creator's API key.
   const experimenterData =
     await getExperimenterDataFromExperiment(experimentId);
@@ -290,6 +289,63 @@ export async function getAgentChatAPIResponse(
     return null;
   }
 
+  if (promptConfig.shouldRespondPromptContext) {
+    // Use custom model settings/configs if provided, else fall back to main prompt's
+    const shouldRespondModelSettings =
+      promptConfig.shouldRespondModelSettings || agentConfig.modelSettings;
+    const shouldRespondGenerationConfig =
+      promptConfig.shouldRespondGenerationConfig ||
+      promptConfig.generationConfig;
+    const shouldRespondStructuredOutputConfig =
+      promptConfig.shouldRespondStructuredOutputConfig ||
+      promptConfig.structuredOutputConfig;
+
+    // Compose the should-respond prompt, appending the same context as the main prompt
+    const shouldRespondPrompt = [
+      promptConfig.shouldRespondPromptContext,
+      getDefaultChatPrompt(
+        profile,
+        agentConfig,
+        pastStageContext,
+        chatMessages,
+        promptConfig,
+        stageConfig as ChatStageConfig,
+      ),
+    ].join('\n\n');
+
+    const shouldRespondResponse = await getAgentResponse(
+      experimenterData,
+      shouldRespondPrompt,
+      shouldRespondModelSettings,
+      shouldRespondGenerationConfig,
+      shouldRespondStructuredOutputConfig,
+    );
+
+    if (shouldRespondResponse.status !== ModelResponseStatus.OK) {
+      // TODO: Surface the error to the experimenter.
+      return null;
+    }
+
+    // Parse should-respond result (assume JSON with shouldRespondField)
+    let shouldRespondParsed: Record<string, string | boolean | number | null>;
+    try {
+      const cleanedText = shouldRespondResponse
+        .text!.replace(/```json\s*|\s*```/g, '')
+        .trim();
+      shouldRespondParsed = JSON.parse(cleanedText);
+    } catch {
+      console.log('Could not parse should-respond JSON!');
+      return null;
+    }
+    const shouldRespondField =
+      shouldRespondStructuredOutputConfig.shouldRespondField || 'shouldRespond';
+    if (!shouldRespondParsed[shouldRespondField]) {
+      // Model says not to respond
+      return null;
+    }
+    // Otherwise, continue to main prompt as usual
+  }
+
   // Create prompt
   const prompt = getDefaultChatPrompt(
     profile,
@@ -297,7 +353,7 @@ export async function getAgentChatAPIResponse(
     pastStageContext,
     chatMessages,
     promptConfig,
-    stageConfig,
+    stageConfig as ChatStageConfig,
   );
 
   const response = await getAgentResponse(
@@ -315,7 +371,7 @@ export async function getAgentChatAPIResponse(
 
   // Add agent message if non-empty
   let message = response.text!;
-  let parsed = '';
+  let parsed: Record<string, string | boolean | number | null>;
 
   if (promptConfig.responseConfig?.isJSON) {
     // Reset message to empty before trying to fill with JSON response
@@ -455,10 +511,15 @@ export async function initiateChatDiscussion(
 
     const promptConfig =
       (await getAgentChatPrompt(experimentId, stageId, agentConfig.agentId)) ??
-      createAgentChatPromptConfig(stageId, StageKind.CHAT, {
-        promptContext:
-          'You are a participant. Respond in a quick sentence if you would like to say something. Otherwise, do not respond.',
-      });
+      createAgentChatPromptConfig(
+        stageId,
+        StageKind.CHAT,
+        AgentPersonaType.PARTICIPANT,
+        {
+          promptContext:
+            'You are a participant. Respond in a quick sentence if you would like to say something. Otherwise, do not respond.',
+        },
+      );
 
     const chatMessages: ChatMessage[] = [];
     const publicStageData = await getChatStagePublicData(
@@ -495,7 +556,7 @@ export async function initiateChatDiscussion(
       ] ?? '';
     const chatMessage = createParticipantChatMessage({
       profile: response.profile,
-      discussionId: publicStageData.currentDiscussionId,
+      discussionId: publicStageData!.currentDiscussionId,
       message: response.message,
       timestamp: Timestamp.now(),
       senderId: response.profileId,

--- a/functions/src/stages/chat.utils.ts
+++ b/functions/src/stages/chat.utils.ts
@@ -322,7 +322,10 @@ export async function getAgentChatAPIResponse(
     );
 
     if (shouldRespondResponse.status !== ModelResponseStatus.OK) {
-      // TODO: Surface the error to the experimenter.
+      console.error(
+        `Error in should-respond response: ${shouldRespondResponse.status}: ${shouldRespondResponse.errorMessage}`,
+      );
+      // TODO: log error to Firestore?
       return null;
     }
 
@@ -365,7 +368,10 @@ export async function getAgentChatAPIResponse(
   );
 
   if (response.status !== ModelResponseStatus.OK) {
-    // TODO: Surface the error to the experimenter.
+    console.error(
+      `Error in message generation response: ${response.status}: ${response.errorMessage}`,
+    );
+    // TODO: log error to Firestore?
     return null;
   }
 

--- a/utils/src/agent.ts
+++ b/utils/src/agent.ts
@@ -124,6 +124,11 @@ export interface AgentChatPromptConfig extends BaseAgentPromptConfig {
   chatSettings: AgentChatSettings;
   // DEPRECATED: Use structuredOutputConfig, not responseConfig
   responseConfig?: AgentResponseConfig;
+  // Optional: LLM prompt and config for deciding whether to respond
+  shouldRespondPromptContext?: string;
+  shouldRespondModelSettings?: AgentModelSettings;
+  shouldRespondGenerationConfig?: ModelGenerationConfig;
+  shouldRespondStructuredOutputConfig?: StructuredOutputConfig;
 }
 
 export enum AgentPersonaType {
@@ -234,6 +239,11 @@ export function createAgentChatPromptConfig(
     chatSettings: config.chatSettings ?? createAgentChatSettings(),
     structuredOutputConfig:
       config.structuredOutputConfig ?? createStructuredOutputConfig(),
+    shouldRespondPromptContext: config.shouldRespondPromptContext,
+    shouldRespondModelSettings: config.shouldRespondModelSettings,
+    shouldRespondGenerationConfig: config.shouldRespondGenerationConfig,
+    shouldRespondStructuredOutputConfig:
+      config.shouldRespondStructuredOutputConfig,
   };
 }
 


### PR DESCRIPTION
This wraps the intervenability prompt in the same header/footer as the main prompt and uses the same json schema, at least for the moment. It's possible to change it but I don't think we need to. One weird artifact is that the decision prompt ends up writing a (usually poor-quality) message that we discard. I don't know if writing the message changes how it responds, though.