### PR TITLE
Update model to gpt-4.1-2025-04-14

### DIFF
--- a/frontend/src/shared/games/bridging_bot.ts
+++ b/frontend/src/shared/games/bridging_bot.ts
@@ -681,7 +681,7 @@ const createBbotAgent = () => {
     }),
     defaultModelSettings: createAgentModelSettings({
       apiType: ApiKeyType.OPENAI_API_KEY,
-      modelName: 'gpt-4o',
+      modelName: 'gpt-4.1-2025-04-14',
     }),
   });
 


### PR DESCRIPTION
This PR updates the default deliberate lab model to `gpt-4.1-2025-04-14`. [Ticket](https://linear.app/bridging-bot/issue/BRI-220/switch-model-in-dl-to-gpt-41)
