### PR TITLE
Allow multi-line chat messages

### DIFF
--- a/frontend/src/components/stages/chat_interface.ts
+++ b/frontend/src/components/stages/chat_interface.ts
@@ -250,10 +250,12 @@ export class ChatInterface extends MobxLitElement {
 
   private renderInput() {
     const handleKeyUp = (e: KeyboardEvent) => {
-      if (e.key === 'Enter') {
+      // Only send if Enter is pressed without Shift or Ctrl/Cmd
+      if (e.key === 'Enter' && !e.shiftKey && !e.ctrlKey && !e.metaKey) {
         this.sendUserInput();
         e.stopPropagation();
       }
+      // Otherwise, allow default behavior (insert newline)
     };
 
     const handleInput = (e: Event) => {

--- a/frontend/src/components/stages/chat_message.ts
+++ b/frontend/src/components/stages/chat_message.ts
@@ -1,14 +1,11 @@
 import '../participant_profile/avatar_icon';
 
-import {observable} from 'mobx';
 import {MobxLitElement} from '@adobe/lit-mobx';
 
 import {CSSResultGroup, html, nothing} from 'lit';
 import {customElement, property} from 'lit/decorators.js';
 import {classMap} from 'lit/directives/class-map.js';
 import {unsafeHTML} from 'lit/directives/unsafe-html.js';
-
-import {Timestamp} from 'firebase/firestore';
 
 import {core} from '../../core/core';
 import {AuthService} from '../../services/auth.service';

--- a/frontend/src/components/stages/chat_message.ts
+++ b/frontend/src/components/stages/chat_message.ts
@@ -6,6 +6,7 @@ import {MobxLitElement} from '@adobe/lit-mobx';
 import {CSSResultGroup, html, nothing} from 'lit';
 import {customElement, property} from 'lit/decorators.js';
 import {classMap} from 'lit/directives/class-map.js';
+import {unsafeHTML} from 'lit/directives/unsafe-html.js';
 
 import {Timestamp} from 'firebase/firestore';
 
@@ -68,6 +69,11 @@ export class ChatMessageComponent extends MobxLitElement {
       );
     };
 
+    const message = chatMessage.message
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/\n/g, '<br/>');
+
     return html`
       <div class=${classes}>
         <avatar-icon .emoji=${profile.avatar} .color=${color()}> </avatar-icon>
@@ -83,7 +89,7 @@ export class ChatMessageComponent extends MobxLitElement {
               )}</span
             >
           </div>
-          <div class="chat-bubble">${chatMessage.message}</div>
+          <div class="chat-bubble">${unsafeHTML(message)}</div>
         </div>
       </div>
     `;
@@ -91,6 +97,11 @@ export class ChatMessageComponent extends MobxLitElement {
 
   renderMediatorMessage(chatMessage: ChatMessage) {
     const profile = chatMessage.profile;
+
+    const message = chatMessage.message
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/\n/g, '<br/>');
 
     return html`
       <div class="chat-message">
@@ -109,7 +120,7 @@ export class ChatMessageComponent extends MobxLitElement {
               )}</span
             >
           </div>
-          <div class="chat-bubble">${chatMessage.message}</div>
+          <div class="chat-bubble">${unsafeHTML(message)}</div>
           ${this.renderDebuggingExplanation(chatMessage)}
         </div>
       </div>


### PR DESCRIPTION
This PR converts `\n` to `<br>` in chat messages (but sanitizes the message strings first). It allows users to use shift-enter or ctrl-enter to write multiline messages.