### PR TITLE
Switch presence functions to v2, explicitly select db for cleanup task

### DIFF
--- a/functions/src/presence.triggers.ts
+++ b/functions/src/presence.triggers.ts
@@ -1,11 +1,10 @@
 import * as admin from 'firebase-admin';
 
-import {database, pubsub} from 'firebase-functions';
+import {database} from 'firebase-functions/v2';
+import {onSchedule} from 'firebase-functions/v2/scheduler';
 import {app} from './app';
 
-const dbInstance = database.instance(
-  `${process.env.GCLOUD_PROJECT}-default-rtdb`,
-);
+const dbInstance = `${process.env.GCLOUD_PROJECT}-default-rtdb`;
 
 /**
  * Mirror presence from RTDB → Firestore and maintain an aggregate node. Use
@@ -18,14 +17,19 @@ const dbInstance = database.instance(
  * Firestore doc path:
  *   experiments/{experimentId}/participants/{participantPrivateId}
  */
-export const mirrorPresenceToFirestore = dbInstance
-  .ref('/status/{experimentId}/{participantPrivateId}/{connectionId}')
-  .onWrite(async (change, context) => {
-    const {experimentId, participantPrivateId, connectionId} = context.params;
+export const mirrorPresenceToFirestore = database.onValueWritten(
+  {
+    instance: dbInstance,
+    ref: '/status/{experimentId}/{participantPrivateId}/{connectionId}',
+    region: 'us-central1',
+    timeoutSeconds: 60,
+  },
+  async (event) => {
+    const {experimentId, participantPrivateId, connectionId} = event.params;
 
     if (connectionId.startsWith('_')) return null;
 
-    const parentRef = change.after.ref.parent; // participantPrivateId
+    const parentRef = event.data.after.ref.parent; // participantPrivateId
     const aggRef = parentRef!.child('_aggregate');
     const fsRef = app
       .firestore()
@@ -70,13 +74,20 @@ export const mirrorPresenceToFirestore = dbInstance
       },
       {merge: true},
     );
-  });
+  },
+);
 
-export const scrubStalePresence = pubsub
-  .schedule('every 24 hours')
-  .onRun(async () => {
+export const scrubStalePresence = onSchedule(
+  {
+    schedule: 'every 24 hours',
+    region: 'us-central1',
+    timeoutSeconds: 300,
+  },
+  async () => {
     const cutoff = Date.now() - 72 * 60 * 60 * 1000; // 72 hours
-    const root = admin.app().database().ref('status');
+    // Explicitly use the same RTDB instance as the trigger
+    const dbUrl = `https://${dbInstance}.firebaseio.com`;
+    const root = admin.app().database(dbUrl).ref('status');
     const usersSnapshot = await root.get();
     const userSnapshots: admin.database.DataSnapshot[] = [];
     for (const userSnapshot of Object.values(usersSnapshot.val() || {})) {
@@ -96,4 +107,5 @@ export const scrubStalePresence = pubsub
         }
       }
     }
-  });
+  },
+);


### PR DESCRIPTION
All the other firebase functions are v2, so now these are as well.

Also select the database for the cleanup task. I suspect it was running on the wrong db.