### PR TITLE
Fixed presence trigger error from v2 update

### DIFF
--- a/functions/src/presence.triggers.ts
+++ b/functions/src/presence.triggers.ts
@@ -26,6 +26,17 @@ export const mirrorPresenceToFirestore = database.onValueWritten(
   },
   async (event) => {
     const {experimentId, participantPrivateId, connectionId} = event.params;
+    if (
+      !(
+        event.params.connectionId &&
+        event.params.participantPrivateId &&
+        event.params.experimentId
+      )
+    ) {
+      // v2 triggers fire on any write to the prefix, even if the params are null. Do not process those
+      // writes.
+      return null;
+    }
 
     if (connectionId.startsWith('_')) return null;
 


### PR DESCRIPTION
v2 db triggers interpret the path more permissively, which was causing the presence trigger to run with no parameters. This was causing an error, though it didn't actually break anything. The change here silences the error.